### PR TITLE
Use original-fs when running on Electron to avoid issues with .asar files (fs module is patched by Electron)

### DIFF
--- a/lib/ncp.js
+++ b/lib/ncp.js
@@ -1,4 +1,4 @@
-var fs = require('fs'),
+var fs = require(process.versions.electron ? 'original-fs' : 'fs'),
     path = require('path');
 
 module.exports = ncp;


### PR DESCRIPTION
@tejohnso please review
